### PR TITLE
Added charOrder for Czech language

### DIFF
--- a/index.html
+++ b/index.html
@@ -440,6 +440,7 @@ $('ul#people&gt;li').tsort();</pre>
 					</tr></tfoot>
 					<tbody>
 						<tr><td>Cyrilic</td><td>абвгдђежзијклљмнњопрстћуфхцчџш</td></tr>
+						<tr><td>Czech</td><td>a[á]cčd[ď]e[éě]h{ch}i[í]n[ň]o[ó]rřsšt[ť]u[úů]y[ý]zž</td></tr>
 						<tr><td>Danish and Norwegian</td><td>æøå[{Aa}]</td></tr>
 						<tr><td>Dutch</td><td>e[éëê]i[ï]o[óöô]u[ü]</td></tr>
 						<tr><td>French</td><td>a[àâ]c[ç]e[éèêë]i[ïî]o[ôœ]u[ûù]</td></tr>


### PR DESCRIPTION
Full Czech alphabet with ordering according to Czech technical standard ČSN 97 6030 is `'a[á]bcčd[ď]e[éě]fgh{ch}i[í]jklmn[ň]o[ó]pqrřsšt[ť]u[úů]vwxy[ý]zž'` (`'a[\u00e1]bc\u010dd[\u010f]e[\u00e9\u011b]fgh{ch}i[\u00ed]jklmn[\u0148]o[\u00f3]pqr\u0159s\u0161t[\u0165]u[\u00fa\u016f]vwxy[\u00fd]z\u017e'`).

Czech technical standard defines sorting for non Czech alphabets as well, so for any latin alphabet it should be `'a[àáâãäåāăąǎǟǡǻȁȃȧᶏḁẚạảấầẩẫậắằẳẵặⱥ]b[ƀƃɓᵬᶀḃḅḇ]c[çćĉċƈȼɕḉ]čd[ďđƌȡɖɗᵭᶁᶑḋḍḏḑḓ]e[èéêëēĕėęěȅȇȩɇᶒḕḗḙḛḝẹẻẽếềểễệⱸ]f[ƒᵮᶂḟ]g[ĝğġģǥǧǵɠᶃḡ]h[ĥħȟɦḣḥḧḩḫẖⱨ]{ch}i[ìíîïĩīĭįǐȉȋɨᶖḭḯỉị]j[ĵǰɉʝ]k[ķƙǩᶄḱḳḵⱪꝁꝃꝅ]l[ĺļľŀłƚȴɫɬɭᶅḷḹḻḽⱡꝉ]m[ɱᵯᶆḿṁṃ]n[ñńņňƞǹȵɲɳᵰᶇṅṇṉṋ]o[òóôõöøōŏőơǒǫǭǿȍȏȫȭȯȱṍṏṑṓọỏốồổỗộớờởỡợⱺꝋꝍ]p[ƥᵱᵽᶈṕṗꝑꝓꝕ]q[ɋʠꝗꝙ]r[ŕŗȑȓɍɼɽɾᵲᵳᶉṙṛṝṟ]řs[śŝşșȿʂᵴᶊṡṣṥṧṩ]št[ţťŧƫƭțȶʈᵵṫṭṯṱẗⱦ]u[ùúûüũūŭůűųưǔǖǘǚǜȕȗᶙṳṵṷṹṻụủứừửữự]v[ʋᶌṽṿⱱⱴꝟ]w[ŵẁẃẅẇẉẘⱳ]x[ᶍẋẍ]y[ýÿŷƴȳɏẏẙỳỵỷỹỿ]z[źżƶȥɀʐʑᵶᶎẑẓẕⱬ]ž'` (`'a[\u00e0\u00e1\u00e2\u00e3\u00e4\u00e5\u0101\u0103\u0105\u01ce\u01df\u01e1\u01fb\u0201\u0203\u0227\u1d8f\u1e01\u1e9a\u1ea1\u1ea3\u1ea5\u1ea7\u1ea9\u1eab\u1ead\u1eaf\u1eb1\u1eb3\u1eb5\u1eb7\u2c65]b[\u0180\u0183\u0253\u1d6c\u1d80\u1e03\u1e05\u1e07]c[\u00e7\u0107\u0109\u010b\u0188\u023c\u0255\u1e09]\u010dd[\u010f\u0111\u018c\u0221\u0256\u0257\u1d6d\u1d81\u1d91\u1e0b\u1e0d\u1e0f\u1e11\u1e13]e[\u00e8\u00e9\u00ea\u00eb\u0113\u0115\u0117\u0119\u011b\u0205\u0207\u0229\u0247\u1d92\u1e15\u1e17\u1e19\u1e1b\u1e1d\u1eb9\u1ebb\u1ebd\u1ebf\u1ec1\u1ec3\u1ec5\u1ec7\u2c78]f[\u0192\u1d6e\u1d82\u1e1f]g[\u011d\u011f\u0121\u0123\u01e5\u01e7\u01f5\u0260\u1d83\u1e21]h[\u0125\u0127\u021f\u0266\u1e23\u1e25\u1e27\u1e29\u1e2b\u1e96\u2c68]{ch}i[\u00ec\u00ed\u00ee\u00ef\u0129\u012b\u012d\u012f\u01d0\u0209\u020b\u0268\u1d96\u1e2d\u1e2f\u1ec9\u1ecb]j[\u0135\u01f0\u0249\u029d]k[\u0137\u0199\u01e9\u1d84\u1e31\u1e33\u1e35\u2c6a\ua741\ua743\ua745]l[\u013a\u013c\u013e\u0140\u0142\u019a\u0234\u026b\u026c\u026d\u1d85\u1e37\u1e39\u1e3b\u1e3d\u2c61\ua749]m[\u0271\u1d6f\u1d86\u1e3f\u1e41\u1e43]n[\u00f1\u0144\u0146\u0148\u019e\u01f9\u0235\u0272\u0273\u1d70\u1d87\u1e45\u1e47\u1e49\u1e4b]o[\u00f2\u00f3\u00f4\u00f5\u00f6\u00f8\u014d\u014f\u0151\u01a1\u01d2\u01eb\u01ed\u01ff\u020d\u020f\u022b\u022d\u022f\u0231\u1e4d\u1e4f\u1e51\u1e53\u1ecd\u1ecf\u1ed1\u1ed3\u1ed5\u1ed7\u1ed9\u1edb\u1edd\u1edf\u1ee1\u1ee3\u2c7a\ua74b\ua74d]p[\u01a5\u1d71\u1d7d\u1d88\u1e55\u1e57\ua751\ua753\ua755]q[\u024b\u02a0\ua757\ua759]r[\u0155\u0157\u0211\u0213\u024d\u027c\u027d\u027e\u1d72\u1d73\u1d89\u1e59\u1e5b\u1e5d\u1e5f]\u0159s[\u015b\u015d\u015f\u0219\u023f\u0282\u1d74\u1d8a\u1e61\u1e63\u1e65\u1e67\u1e69]\u0161t[\u0163\u0165\u0167\u01ab\u01ad\u021b\u0236\u0288\u1d75\u1e6b\u1e6d\u1e6f\u1e71\u1e97\u2c66]u[\u00f9\u00fa\u00fb\u00fc\u0169\u016b\u016d\u016f\u0171\u0173\u01b0\u01d4\u01d6\u01d8\u01da\u01dc\u0215\u0217\u1d99\u1e73\u1e75\u1e77\u1e79\u1e7b\u1ee5\u1ee7\u1ee9\u1eeb\u1eed\u1eef\u1ef1]v[\u028b\u1d8c\u1e7d\u1e7f\u2c71\u2c74\ua75f]w[\u0175\u1e81\u1e83\u1e85\u1e87\u1e89\u1e98\u2c73]x[\u1d8d\u1e8b\u1e8d]y[\u00fd\u00ff\u0177\u01b4\u0233\u024f\u1e8f\u1e99\u1ef3\u1ef5\u1ef7\u1ef9\u1eff]z[\u017a\u017c\u01b6\u0225\u0240\u0290\u0291\u1d76\u1d8e\u1e91\u1e93\u1e95\u2c6c]\u017e'`).

I created above list by listing all unicode letters. For example for a, I searched for all letter names starting with `'LATIN SMALL LETTER A WITH '`.
