### PR TITLE
Resolved issue with unrecognized numbers

### DIFF
--- a/src/jquery.tinysort.js
+++ b/src/jquery.tinysort.js
@@ -127,6 +127,9 @@
 							// maybe toLower
 								,sA = !oSett.cases?toLowerCase(a.s[iCriteria]):a.s[iCriteria]
 								,sB = !oSett.cases?toLowerCase(b.s[iCriteria]):b.s[iCriteria];
+							//strip leading and trailing whitespaces
+								sA=sA.replace(/^\s*/i,'').replace(/\s*$/i,'');
+								sB=sB.replace(/^\s*/i,'').replace(/\s*$/i,'');
 							// maybe force Strings
 							if (!oSettings.forceStrings) {
 								// maybe mixed


### PR DESCRIPTION
Numbers are not recognized as numbers, when there are leading and trailing whitespace characters.
Added 2 lines to strip them from items being compared.
