### PR TITLE
Fix incorrect handling of number-only Strings read via jQuery API

### DIFF
--- a/src/jquery.tinysort.js
+++ b/src/jquery.tinysort.js
@@ -226,9 +226,11 @@
 				for (j=0;j<iCriteriaMax;j++) {
 					var oPoint = aCriteria[j]
 						// element or sub selection
-						,mElmOrSub = oPoint.bFind?(oPoint.bFilter?oPoint.$Filter.filter(el):$Elm.find(oPoint.sFind)):$Elm;
-					// text or attribute value
-					aSort.push(oPoint.bData?mElmOrSub.data(oPoint.oSettings.data):(oPoint.bAttr?mElmOrSub.attr(oPoint.oSettings.attr):(oPoint.oSettings.useVal?mElmOrSub.val():mElmOrSub.text())));
+						,mElmOrSub = oPoint.bFind ? (oPoint.bFilter ? oPoint.$Filter.filter(el) : $Elm.find(oPoint.sFind)) : $Elm
+						// text or attribute value
+						,mVal = oPoint.bData ? mElmOrSub.data(oPoint.oSettings.data) : (oPoint.bAttr ? mElmOrSub.attr(oPoint.oSettings.attr) : (oPoint.oSettings.useVal ? mElmOrSub.val() : mElmOrSub.text()));
+					// make sure to push strings only
+					aSort.push(mVal ? mVal.toString() : "");
 					if (mFirstElmOrSub===undefined) mFirstElmOrSub = mElmOrSub;
 				}
 				// to sort or not to sort


### PR DESCRIPTION
##### Example

When sorting the following example with {data: 'value'}, the two numeric values will be received as Number instead of String, which will extremely screw up sorting.

``` html
<ul class="sort">
    <li data-value="500">500</li>
    <li data-value="8">8</li>
    <li data-value="bar">bar</li>
    <li data-value="foo">foo</li>
</ul>
```
##### Solution

As all elements internally are meant to be Strings anyway it makes sense to force cast them when reading their values via the jQuery API from data(), attr(), val() or text().
