### PR TITLE
Added option to place index as data attribute

### DIFF
--- a/src/jquery.tinysort.js
+++ b/src/jquery.tinysort.js
@@ -93,6 +93,7 @@
 			,ignoreDashes:fls		// ignores dashes when looking for numerals
 
 			,sortFunction: nll		// override the default sort function
+			,dataIndex: false               // if true, will add a data-index attribute to sorted elements
 		}
 	};
 	$.fn.extend({
@@ -265,6 +266,7 @@
 					var bFromSortList = contains(aOriginal,i)?!fls:i>=iLow&&i<iLow+iSorted
                         ,iCountIndex = bFromSortList?0:1
 						,mEl = (bFromSortList?aSorted:aUnsorted)[aCount[iCountIndex]].e;
+					if(oSettings.dataIndex) mEl.attr('data-index', i);	
 					mEl.parent().append(mEl);
 					if (bFromSortList||!oSettings.returns) aNewOrder.push(mEl.get(0));
 					aCount[iCountIndex]++;


### PR DESCRIPTION
Based on a [StackOverflow question](http://stackoverflow.com/questions/25391629/tiny-sort-add-numbering-to-the-sorted-elements), which I felt would be a handy addition, this PR allows to add a data attribute with the index number on the sorted elements.
