### PR TITLE
Add option to include space sensitive sorting

### DIFF
--- a/src/jquery.tinysort.js
+++ b/src/jquery.tinysort.js
@@ -80,14 +80,16 @@
 
 			 order: 'asc'			// order: asc, desc or rand
 
-			,attr: nll				// order by attribute value
-			,data: nll				// use the data attribute for sorting
+			,attr: nll			// order by attribute value
+			,data: nll			// use the data attribute for sorting
 			,useVal: fls			// use element value instead of text
 
 			,place: 'start'			// place ordered elements at position: start, end, org (original position), first
 			,returns: fls			// return all elements or only the sorted ones (true/false)
 
-			,cases: fls				// a case sensitive sort orders [aB,aa,ab,bb]
+			,cases: fls			// a case sensitive sort orders [aB,aa,ab,bb]
+			,spaces: fls                    // a space sensitive sort orders [ a, b,aa,ab]
+			
 			,forceStrings:fls		// if false the string '2' will sort with the value 2, not the string '2'
 
 			,ignoreDashes:fls		// ignores dashes when looking for numerals
@@ -119,9 +121,8 @@
 				//
 				,fnPrepareSortElement = function(settings,element){
 					if (typeof element=='string') {
-						// if !settings.cases
-						if (!settings.cases) element = toLowerCase(element);
-						element = element.replace(/^\s*(.*?)\s*$/i, '$1');
+						element = settings.cases  ? element : toLowerCase(element);
+						element = settings.spaces ? element : element.replace(/^\s*(.*?)\s*$/i, '$1');
 					}
 					return element;
 				}


### PR DESCRIPTION
This doesn't seem like something you would want, but some users use spaces to manually sort items atop of lists. This would make that sort space sensitive and treat a space like any other non alphanumeric character and sort to the top.

 I am not familiar with qunit or I would have written a spec initially. If a spec is expected for the PR to be merged, then I will need a little more time to figure it out. 

Thanks for all the work you've done!! 