### PR TITLE
Added check for if parentNode has been removed

### DIFF
--- a/src/tinysort.js
+++ b/src/tinysort.js
@@ -292,7 +292,12 @@
 						elmObj.elm.style.order = i;
 					});
 				} else {
-					parentNode.appendChild(sortedIntoFragment());
+					if (parentNode) {
+						parentNode.appendChild(sortedIntoFragment());
+					}
+					else {
+						console.warn("parentNode has been removed");
+					}
 				}
 			} else {
 				var criterium = criteria[0]


### PR DESCRIPTION
Using the code at http://tinysort.sjeiti.com/#sorting-tables to sort a table, then dynamically removing all rows from the table will produce an error 'Uncaught TypeError: Cannot read property 'appendChild' of undefined' once the table is completely empty. 

Adding a small check to see if the parent still exists will remove this error.

Awesome work by the way!