### PR TITLE
Migrate emmetio package to monorepo

### DIFF
--- a/doc/js/util.js
+++ b/doc/js/util.js
@@ -1,4 +1,4 @@
-import { expand } from '@emmetio/expand-abbreviation'
+import { expand } from '@emmetio/abbreviation'
 
 /**
  * Turn a title into a slug

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.2.8",
       "license": "MIT",
       "dependencies": {
-        "@emmetio/expand-abbreviation": "^0.7.1",
+        "@emmetio/abbreviation": "^2.3.3",
         "lodash": "^4.17.11",
         "tough-cookie": "^2.5.0"
       },
@@ -45,147 +45,17 @@
       }
     },
     "node_modules/@emmetio/abbreviation": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/@emmetio/abbreviation/-/abbreviation-0.6.6.tgz",
-      "integrity": "sha512-jsh1Hyc7iY+5tADcn6GlIF/kxEbglPW+JE/FcCb4NNYqDr2swXvEGWd+DN3porBA67VDfDZVAwThhvYTsHKrRw==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@emmetio/abbreviation/-/abbreviation-2.3.3.tgz",
+      "integrity": "sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA==",
       "dependencies": {
-        "@emmetio/node": "^0.1.2",
-        "@emmetio/stream-reader": "^2.2.0",
-        "@emmetio/stream-reader-utils": "^0.1.0"
+        "@emmetio/scanner": "^1.0.4"
       }
     },
-    "node_modules/@emmetio/css-abbreviation": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@emmetio/css-abbreviation/-/css-abbreviation-0.4.0.tgz",
-      "integrity": "sha512-8b4+ZoBElpNMedO+gGCiEX/xGv8Do0NYUvsdVNv6O0fuP9octnxyzjb7HFGqDJ7hFzVORAfzOhpjyL8y2dw9AQ==",
-      "dependencies": {
-        "@emmetio/node": "^0.1.2",
-        "@emmetio/stream-reader": "^2.2.0",
-        "@emmetio/stream-reader-utils": "^0.1.0"
-      }
-    },
-    "node_modules/@emmetio/css-snippets-resolver": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@emmetio/css-snippets-resolver/-/css-snippets-resolver-0.4.0.tgz",
-      "integrity": "sha512-H0eOed2KljA/nQ64j3BKwAkAFliku5LAD58o4pvS3A9tZ2g3ctEpJ+61po78SZE1+Q+gRA3CGtC6rxtk7QlGPA=="
-    },
-    "node_modules/@emmetio/expand-abbreviation": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@emmetio/expand-abbreviation/-/expand-abbreviation-0.7.1.tgz",
-      "integrity": "sha512-9sLbnSRgcaNQ/HNr/9TYtM8jnHfbFymojaXdRMZjXbtg7wPZQWmTXMM+aM++L8pET6cxA2N/QHLa1iMRfkLavg==",
-      "dependencies": {
-        "@emmetio/abbreviation": "^0.6.6",
-        "@emmetio/css-abbreviation": "^0.4.0",
-        "@emmetio/css-snippets-resolver": "^0.4.0",
-        "@emmetio/html-snippets-resolver": "^0.1.4",
-        "@emmetio/html-transform": "^0.3.9",
-        "@emmetio/lorem": "^1.0.1",
-        "@emmetio/markup-formatters": "^0.4.0",
-        "@emmetio/output-profile": "^0.1.6",
-        "@emmetio/snippets": "^0.2.9",
-        "@emmetio/snippets-registry": "^0.3.1",
-        "@emmetio/stylesheet-formatters": "^0.2.1",
-        "@emmetio/variable-resolver": "^0.2.1"
-      }
-    },
-    "node_modules/@emmetio/field-parser": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@emmetio/field-parser/-/field-parser-0.3.1.tgz",
-      "integrity": "sha512-A26JuVvZRUBb/rNpaDdmBB2jaN3spx2JRLJQfkskz9CRbiSW9ZE/M7etKKMunV5UWUfSlygFaFUclT3y+UNDxw==",
-      "dependencies": {
-        "@emmetio/stream-reader": "^2.2.0",
-        "@emmetio/stream-reader-utils": "^0.1.0"
-      }
-    },
-    "node_modules/@emmetio/html-snippets-resolver": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@emmetio/html-snippets-resolver/-/html-snippets-resolver-0.1.4.tgz",
-      "integrity": "sha1-szrT+nj9eNZLlL+Iqftos62Ojn4=",
-      "dependencies": {
-        "@emmetio/abbreviation": "^0.6.0"
-      }
-    },
-    "node_modules/@emmetio/html-transform": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/@emmetio/html-transform/-/html-transform-0.3.10.tgz",
-      "integrity": "sha512-GxKcFDCkHQAre4lBRr4hbyYfRhAtTqDrcnwDi2n97CX6bKhdfL9p7fZIobtNtjX+ZdCVs36x4vizpiChEYOArg==",
-      "dependencies": {
-        "@emmetio/implicit-tag": "^1.0.0"
-      }
-    },
-    "node_modules/@emmetio/implicit-tag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@emmetio/implicit-tag/-/implicit-tag-1.0.0.tgz",
-      "integrity": "sha1-+CbU4fxR2jlDTCMmtvbQ4rLntBk="
-    },
-    "node_modules/@emmetio/lorem": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@emmetio/lorem/-/lorem-1.0.2.tgz",
-      "integrity": "sha1-jealcY85Fy6n0iUypbDTu9EAg9w=",
-      "dependencies": {
-        "@emmetio/implicit-tag": "^1.0.0"
-      }
-    },
-    "node_modules/@emmetio/markup-formatters": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@emmetio/markup-formatters/-/markup-formatters-0.4.0.tgz",
-      "integrity": "sha512-Y0dkfZwzdRUJkiFOe4Tx8Hye0EK9AMT7VgqoCM1IkGsRiLNm+uI5eAMoN6uVBQwack7p7ZswWC0LLeUvc3ko4g==",
-      "dependencies": {
-        "@emmetio/field-parser": "^0.3.0",
-        "@emmetio/output-renderer": "^0.1.2"
-      }
-    },
-    "node_modules/@emmetio/node": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@emmetio/node/-/node-0.1.2.tgz",
-      "integrity": "sha1-QjHVOMRUgaUYNfwquj9dn8EpY0w="
-    },
-    "node_modules/@emmetio/output-profile": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@emmetio/output-profile/-/output-profile-0.1.6.tgz",
-      "integrity": "sha512-7bIwR3YHmTEnyy76X4l9e5+wXE+lah2E1AIoeDyKFIfVujztXNqcv+BmPcV4LRl1+V6Qir8hIex+F2nz7PTPCg=="
-    },
-    "node_modules/@emmetio/output-renderer": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@emmetio/output-renderer/-/output-renderer-0.1.2.tgz",
-      "integrity": "sha1-Ds4RrM6SmFB4aK7SGrUlPh6wgvg=",
-      "dependencies": {
-        "@emmetio/field-parser": "^0.3.0"
-      }
-    },
-    "node_modules/@emmetio/snippets": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@emmetio/snippets/-/snippets-0.2.9.tgz",
-      "integrity": "sha512-n/oaJMcKB5No8Q1wnxfHmrZV2LA40cmYMwVbH0ebfpiZSxX1EMY26QaYu+PJiGcqR+GElS79aMagIO+dOTCntw=="
-    },
-    "node_modules/@emmetio/snippets-registry": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@emmetio/snippets-registry/-/snippets-registry-0.3.1.tgz",
-      "integrity": "sha1-7A6KEi/paDZZzmmiI5b0E2uUDSA="
-    },
-    "node_modules/@emmetio/stream-reader": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@emmetio/stream-reader/-/stream-reader-2.2.0.tgz",
-      "integrity": "sha1-Rs/+oRmgoAMxKiHC2bVijLX81EI="
-    },
-    "node_modules/@emmetio/stream-reader-utils": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@emmetio/stream-reader-utils/-/stream-reader-utils-0.1.0.tgz",
-      "integrity": "sha1-JEywLHfsLnT3ipvTGCGKvJxQCmE="
-    },
-    "node_modules/@emmetio/stylesheet-formatters": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@emmetio/stylesheet-formatters/-/stylesheet-formatters-0.2.1.tgz",
-      "integrity": "sha512-1XHNVx6S3ra7dnv12CNT6Gq15VyT2Fkrhgp2yCj4g2jJJflVHU6t++VfjoK6w36hGYu0AqZL9TCa/8hLj2YjQw==",
-      "dependencies": {
-        "@emmetio/field-parser": "^0.3.0",
-        "@emmetio/output-renderer": "^0.1.1"
-      }
-    },
-    "node_modules/@emmetio/variable-resolver": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@emmetio/variable-resolver/-/variable-resolver-0.2.1.tgz",
-      "integrity": "sha1-zhG1FYRmmjQJhmkM8OwmnkTGP7o="
+    "node_modules/@emmetio/scanner": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@emmetio/scanner/-/scanner-1.0.4.tgz",
+      "integrity": "sha512-IqRuJtQff7YHHBk4G8YZ45uB9BaAGcwQeVzgj/zj8/UdOhtQpEIupUhSk8dys6spFIWVZVeK20CzGEnqR5SbqA=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -6201,6 +6071,7 @@
         "tar"
       ],
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
@@ -16264,147 +16135,17 @@
   },
   "dependencies": {
     "@emmetio/abbreviation": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/@emmetio/abbreviation/-/abbreviation-0.6.6.tgz",
-      "integrity": "sha512-jsh1Hyc7iY+5tADcn6GlIF/kxEbglPW+JE/FcCb4NNYqDr2swXvEGWd+DN3porBA67VDfDZVAwThhvYTsHKrRw==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@emmetio/abbreviation/-/abbreviation-2.3.3.tgz",
+      "integrity": "sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA==",
       "requires": {
-        "@emmetio/node": "^0.1.2",
-        "@emmetio/stream-reader": "^2.2.0",
-        "@emmetio/stream-reader-utils": "^0.1.0"
+        "@emmetio/scanner": "^1.0.4"
       }
     },
-    "@emmetio/css-abbreviation": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@emmetio/css-abbreviation/-/css-abbreviation-0.4.0.tgz",
-      "integrity": "sha512-8b4+ZoBElpNMedO+gGCiEX/xGv8Do0NYUvsdVNv6O0fuP9octnxyzjb7HFGqDJ7hFzVORAfzOhpjyL8y2dw9AQ==",
-      "requires": {
-        "@emmetio/node": "^0.1.2",
-        "@emmetio/stream-reader": "^2.2.0",
-        "@emmetio/stream-reader-utils": "^0.1.0"
-      }
-    },
-    "@emmetio/css-snippets-resolver": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@emmetio/css-snippets-resolver/-/css-snippets-resolver-0.4.0.tgz",
-      "integrity": "sha512-H0eOed2KljA/nQ64j3BKwAkAFliku5LAD58o4pvS3A9tZ2g3ctEpJ+61po78SZE1+Q+gRA3CGtC6rxtk7QlGPA=="
-    },
-    "@emmetio/expand-abbreviation": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@emmetio/expand-abbreviation/-/expand-abbreviation-0.7.1.tgz",
-      "integrity": "sha512-9sLbnSRgcaNQ/HNr/9TYtM8jnHfbFymojaXdRMZjXbtg7wPZQWmTXMM+aM++L8pET6cxA2N/QHLa1iMRfkLavg==",
-      "requires": {
-        "@emmetio/abbreviation": "^0.6.6",
-        "@emmetio/css-abbreviation": "^0.4.0",
-        "@emmetio/css-snippets-resolver": "^0.4.0",
-        "@emmetio/html-snippets-resolver": "^0.1.4",
-        "@emmetio/html-transform": "^0.3.9",
-        "@emmetio/lorem": "^1.0.1",
-        "@emmetio/markup-formatters": "^0.4.0",
-        "@emmetio/output-profile": "^0.1.6",
-        "@emmetio/snippets": "^0.2.9",
-        "@emmetio/snippets-registry": "^0.3.1",
-        "@emmetio/stylesheet-formatters": "^0.2.1",
-        "@emmetio/variable-resolver": "^0.2.1"
-      }
-    },
-    "@emmetio/field-parser": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@emmetio/field-parser/-/field-parser-0.3.1.tgz",
-      "integrity": "sha512-A26JuVvZRUBb/rNpaDdmBB2jaN3spx2JRLJQfkskz9CRbiSW9ZE/M7etKKMunV5UWUfSlygFaFUclT3y+UNDxw==",
-      "requires": {
-        "@emmetio/stream-reader": "^2.2.0",
-        "@emmetio/stream-reader-utils": "^0.1.0"
-      }
-    },
-    "@emmetio/html-snippets-resolver": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@emmetio/html-snippets-resolver/-/html-snippets-resolver-0.1.4.tgz",
-      "integrity": "sha1-szrT+nj9eNZLlL+Iqftos62Ojn4=",
-      "requires": {
-        "@emmetio/abbreviation": "^0.6.0"
-      }
-    },
-    "@emmetio/html-transform": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/@emmetio/html-transform/-/html-transform-0.3.10.tgz",
-      "integrity": "sha512-GxKcFDCkHQAre4lBRr4hbyYfRhAtTqDrcnwDi2n97CX6bKhdfL9p7fZIobtNtjX+ZdCVs36x4vizpiChEYOArg==",
-      "requires": {
-        "@emmetio/implicit-tag": "^1.0.0"
-      }
-    },
-    "@emmetio/implicit-tag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@emmetio/implicit-tag/-/implicit-tag-1.0.0.tgz",
-      "integrity": "sha1-+CbU4fxR2jlDTCMmtvbQ4rLntBk="
-    },
-    "@emmetio/lorem": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@emmetio/lorem/-/lorem-1.0.2.tgz",
-      "integrity": "sha1-jealcY85Fy6n0iUypbDTu9EAg9w=",
-      "requires": {
-        "@emmetio/implicit-tag": "^1.0.0"
-      }
-    },
-    "@emmetio/markup-formatters": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@emmetio/markup-formatters/-/markup-formatters-0.4.0.tgz",
-      "integrity": "sha512-Y0dkfZwzdRUJkiFOe4Tx8Hye0EK9AMT7VgqoCM1IkGsRiLNm+uI5eAMoN6uVBQwack7p7ZswWC0LLeUvc3ko4g==",
-      "requires": {
-        "@emmetio/field-parser": "^0.3.0",
-        "@emmetio/output-renderer": "^0.1.2"
-      }
-    },
-    "@emmetio/node": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@emmetio/node/-/node-0.1.2.tgz",
-      "integrity": "sha1-QjHVOMRUgaUYNfwquj9dn8EpY0w="
-    },
-    "@emmetio/output-profile": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@emmetio/output-profile/-/output-profile-0.1.6.tgz",
-      "integrity": "sha512-7bIwR3YHmTEnyy76X4l9e5+wXE+lah2E1AIoeDyKFIfVujztXNqcv+BmPcV4LRl1+V6Qir8hIex+F2nz7PTPCg=="
-    },
-    "@emmetio/output-renderer": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@emmetio/output-renderer/-/output-renderer-0.1.2.tgz",
-      "integrity": "sha1-Ds4RrM6SmFB4aK7SGrUlPh6wgvg=",
-      "requires": {
-        "@emmetio/field-parser": "^0.3.0"
-      }
-    },
-    "@emmetio/snippets": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@emmetio/snippets/-/snippets-0.2.9.tgz",
-      "integrity": "sha512-n/oaJMcKB5No8Q1wnxfHmrZV2LA40cmYMwVbH0ebfpiZSxX1EMY26QaYu+PJiGcqR+GElS79aMagIO+dOTCntw=="
-    },
-    "@emmetio/snippets-registry": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@emmetio/snippets-registry/-/snippets-registry-0.3.1.tgz",
-      "integrity": "sha1-7A6KEi/paDZZzmmiI5b0E2uUDSA="
-    },
-    "@emmetio/stream-reader": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@emmetio/stream-reader/-/stream-reader-2.2.0.tgz",
-      "integrity": "sha1-Rs/+oRmgoAMxKiHC2bVijLX81EI="
-    },
-    "@emmetio/stream-reader-utils": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@emmetio/stream-reader-utils/-/stream-reader-utils-0.1.0.tgz",
-      "integrity": "sha1-JEywLHfsLnT3ipvTGCGKvJxQCmE="
-    },
-    "@emmetio/stylesheet-formatters": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@emmetio/stylesheet-formatters/-/stylesheet-formatters-0.2.1.tgz",
-      "integrity": "sha512-1XHNVx6S3ra7dnv12CNT6Gq15VyT2Fkrhgp2yCj4g2jJJflVHU6t++VfjoK6w36hGYu0AqZL9TCa/8hLj2YjQw==",
-      "requires": {
-        "@emmetio/field-parser": "^0.3.0",
-        "@emmetio/output-renderer": "^0.1.1"
-      }
-    },
-    "@emmetio/variable-resolver": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@emmetio/variable-resolver/-/variable-resolver-0.2.1.tgz",
-      "integrity": "sha1-zhG1FYRmmjQJhmkM8OwmnkTGP7o="
+    "@emmetio/scanner": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@emmetio/scanner/-/scanner-1.0.4.tgz",
+      "integrity": "sha512-IqRuJtQff7YHHBk4G8YZ45uB9BaAGcwQeVzgj/zj8/UdOhtQpEIupUhSk8dys6spFIWVZVeK20CzGEnqR5SbqA=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "serve:test": "node task/serve test 8877"
   },
   "dependencies": {
-    "@emmetio/expand-abbreviation": "^0.7.1",
+    "@emmetio/abbreviation": "^2.3.3",
     "lodash": "^4.17.11",
     "tough-cookie": "^2.5.0"
   },


### PR DESCRIPTION
Our CI is failing because it appears the `@emmetio/expand-abbreviation` package has been dropped from the NPM registry. This package has since been amalgamated into a new monorepo by emmetio here: https://github.com/emmetio/emmet/tree/master/packages/abbreviation

This PR updates to the new package. Jest (`npm run js:test`) is green locally.